### PR TITLE
Create interaction modifier to allow/prevent dropping items

### DIFF
--- a/core/src/main/java/dev/triumphteam/gui/builder/gui/BaseGuiBuilder.java
+++ b/core/src/main/java/dev/triumphteam/gui/builder/gui/BaseGuiBuilder.java
@@ -116,6 +116,18 @@ public abstract class BaseGuiBuilder<G extends BaseGui, B extends BaseGuiBuilder
     }
 
     /**
+     * Disable item drop inside the GUI
+     *
+     * @return The builder
+     * @since 3.0.3
+     */
+    @Contract(" -> this")
+    public B disableItemDrop() {
+        interactionModifiers.add(InteractionModifier.PREVENT_ITEM_DROP);
+        return (B) this;
+    }
+
+    /**
      * Disable all the modifications of the GUI, making it immutable by player interaction
      *
      * @return The builder
@@ -164,6 +176,18 @@ public abstract class BaseGuiBuilder<G extends BaseGui, B extends BaseGuiBuilder
     @Contract(" -> this")
     public B enableItemSwap() {
         interactionModifiers.remove(InteractionModifier.PREVENT_ITEM_SWAP);
+        return (B) this;
+    }
+
+    /**
+     * Allows item drop inside the GUI
+     *
+     * @return The builder
+     * @since 3.0.3
+     */
+    @Contract(" -> this")
+    public B enableItemDrop() {
+        interactionModifiers.remove(InteractionModifier.PREVENT_ITEM_DROP);
         return (B) this;
     }
 

--- a/core/src/main/java/dev/triumphteam/gui/components/InteractionModifier.java
+++ b/core/src/main/java/dev/triumphteam/gui/components/InteractionModifier.java
@@ -36,7 +36,8 @@ import java.util.Set;
 public enum InteractionModifier {
     PREVENT_ITEM_PLACE,
     PREVENT_ITEM_TAKE,
-    PREVENT_ITEM_SWAP;
+    PREVENT_ITEM_SWAP,
+    PREVENT_ITEM_DROP;
 
     public static final Set<InteractionModifier> VALUES = Collections.unmodifiableSet(EnumSet.allOf(InteractionModifier.class));
 }

--- a/core/src/main/java/dev/triumphteam/gui/guis/BaseGui.java
+++ b/core/src/main/java/dev/triumphteam/gui/guis/BaseGui.java
@@ -528,6 +528,18 @@ public abstract class BaseGui implements InventoryHolder {
     }
 
     /**
+     * Disable item drop inside the GUI
+     *
+     * @return The BaseGui
+     * @since 3.0.3.
+     */
+    @Contract(" -> this")
+    public BaseGui disableItemDrop() {
+        interactionModifiers.add(InteractionModifier.PREVENT_ITEM_DROP);
+        return this;
+    }
+
+    /**
      * Disable all the modifications of the GUI, making it immutable by player interaction.
      *
      * @return The BaseGui.
@@ -580,6 +592,18 @@ public abstract class BaseGui implements InventoryHolder {
     }
 
     /**
+     * Allows item drop inside the GUI
+     *
+     * @return The BaseGui
+     * @since 3.0.3
+     */
+    @Contract(" -> this")
+    public BaseGui enableItemDrop() {
+        interactionModifiers.remove(InteractionModifier.PREVENT_ITEM_DROP);
+        return this;
+    }
+
+    /**
      * Enable all modifications of the GUI, making it completely mutable by player interaction.
      *
      * @return The BaseGui.
@@ -623,6 +647,16 @@ public abstract class BaseGui implements InventoryHolder {
      */
     public boolean canSwapItems() {
         return !interactionModifiers.contains(InteractionModifier.PREVENT_ITEM_SWAP);
+    }
+
+    /**
+     * Check if item drop is allowed inside this GUI
+     *
+     * @return True if item drop is allowed for this GUI
+     * @since 3.0.3
+     */
+    public boolean canDropItems() {
+        return !interactionModifiers.contains(InteractionModifier.PREVENT_ITEM_DROP);
     }
 
     /**

--- a/core/src/main/java/dev/triumphteam/gui/guis/InteractionModifierListener.java
+++ b/core/src/main/java/dev/triumphteam/gui/guis/InteractionModifierListener.java
@@ -60,7 +60,7 @@ public final class InteractionModifierListener implements Listener {
         final BaseGui gui = (BaseGui) event.getInventory().getHolder();
 
         // if player is trying to do a disabled action, cancel it
-        if ((!gui.canPlaceItems() && isPlaceItemEvent(event)) || (!gui.canTakeItems() && isTakeItemEvent(event)) || (!gui.canSwapItems() && isSwapItemEvent(event))) {
+        if ((!gui.canPlaceItems() && isPlaceItemEvent(event)) || (!gui.canTakeItems() && isTakeItemEvent(event)) || (!gui.canSwapItems() && isSwapItemEvent(event)) || (!gui.canDropItems() && isDropItemEvent(event))) {
             event.setCancelled(true);
             event.setResult(Event.Result.DENY);
         }
@@ -157,6 +157,17 @@ public final class InteractionModifierListener implements Listener {
             && inventory.getType() != InventoryType.PLAYER;
     }
 
+    private boolean isDropItemEvent(final InventoryClickEvent event) {
+        Preconditions.checkNotNull(event, "event cannot be null");
+
+        final Inventory inventory = event.getInventory();
+        final Inventory clickedInventory = event.getClickedInventory();
+        final InventoryAction action = event.getAction();
+
+        return isDropAction(action)
+                && (clickedInventory != null || inventory.getType() != InventoryType.PLAYER);
+    }
+
     /**
      * Checks if any item is being dragged on the GUI
      *
@@ -185,6 +196,11 @@ public final class InteractionModifierListener implements Listener {
     private boolean isSwapAction(final InventoryAction action) {
         Preconditions.checkNotNull(action, "action cannot be null");
         return action == InventoryAction.SWAP_WITH_CURSOR;
+    }
+
+    private boolean isDropAction(final InventoryAction action) {
+        Preconditions.checkNotNull(action, "action cannot be null");
+        return action == InventoryAction.DROP_ONE_SLOT || action == InventoryAction.DROP_ALL_SLOT;
     }
 
     /**


### PR DESCRIPTION
Whilst developing a plugin using this library I've come across an issue where you're able to drop items from the GUI by pressing 'Q' (or whatever key is binded to dropping an item). I've made some simple additions to make this optional by adding it to the InteractionModifier enum.