### PR TITLE
Fixed IS_SKULL_OWNER_LEGACY, not considering 1.12

### DIFF
--- a/core/src/main/java/dev/triumphteam/gui/components/util/VersionHelper.java
+++ b/core/src/main/java/dev/triumphteam/gui/components/util/VersionHelper.java
@@ -80,7 +80,7 @@ public final class VersionHelper {
      * Checks if the version doesn't have {@link org.bukkit.inventory.meta.SkullMeta#setOwningPlayer(OfflinePlayer)} and
      * {@link org.bukkit.inventory.meta.SkullMeta#setOwner(String)} should be used instead
      */
-    public static final boolean IS_SKULL_OWNER_LEGACY = CURRENT_VERSION < V1_12;
+    public static final boolean IS_SKULL_OWNER_LEGACY = CURRENT_VERSION <= V1_12;
 
     /**
      * Checks if the version has {@link org.bukkit.inventory.meta.ItemMeta#setCustomModelData(Integer)}

--- a/core/src/main/java/dev/triumphteam/gui/components/util/VersionHelper.java
+++ b/core/src/main/java/dev/triumphteam/gui/components/util/VersionHelper.java
@@ -48,7 +48,7 @@ public final class VersionHelper {
     // Paper adventure changes
     private static final int V1_16_5 = 1165;
     // SkullMeta#setOwningPlayer was added
-    private static final int V1_12 = 1120;
+    private static final int V1_12_1 = 1121;
 
     private static final int CURRENT_VERSION = getCurrentVersion();
 
@@ -80,7 +80,7 @@ public final class VersionHelper {
      * Checks if the version doesn't have {@link org.bukkit.inventory.meta.SkullMeta#setOwningPlayer(OfflinePlayer)} and
      * {@link org.bukkit.inventory.meta.SkullMeta#setOwner(String)} should be used instead
      */
-    public static final boolean IS_SKULL_OWNER_LEGACY = CURRENT_VERSION <= V1_12;
+    public static final boolean IS_SKULL_OWNER_LEGACY = CURRENT_VERSION < V1_12_1;
 
     /**
      * Checks if the version has {@link org.bukkit.inventory.meta.ItemMeta#setCustomModelData(Integer)}


### PR DESCRIPTION
SkullMeta#setOwningPlayer(OfflinePlayer) was added in 1.12.1, not 1.12.