### PR TITLE
GuiItem - do not mutate given ItemStack

### DIFF
--- a/core/src/main/java/dev/triumphteam/gui/guis/GuiItem.java
+++ b/core/src/main/java/dev/triumphteam/gui/guis/GuiItem.java
@@ -62,7 +62,7 @@ public class GuiItem {
         this.action = action;
 
         // Sets the UUID to an NBT tag to be identifiable later
-        this.itemStack = ItemNbt.setString(itemStack, "mf-gui", uuid.toString());
+        this.itemStack = ItemNbt.setString(itemStack.clone(), "mf-gui", uuid.toString());
     }
 
     /**
@@ -100,7 +100,7 @@ public class GuiItem {
      */
     public void setItemStack(@NotNull final ItemStack itemStack) {
         Validate.notNull(itemStack, "The ItemStack for the GUI Item cannot be null!");
-        this.itemStack = ItemNbt.setString(itemStack, "mf-gui", uuid.toString());
+        this.itemStack = ItemNbt.setString(itemStack.clone(), "mf-gui", uuid.toString());
     }
 
     /**


### PR DESCRIPTION
Using GuiItem constructor with an ItemStack, or using `GuiItem.setItemStack` method adds NBT data to the provided ItemStack, which is an unexpected and undocumented behaviour.
This pull request updates the GuiItem constructor and `GuiItem.setItemStack` method, so that the ItemStacks are cloned before being mutated.