### PR TITLE
feat: use the *new* PlayerProfile API on 1.20.1+

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ subprojects {
 
     dependencies {
         compileOnly("org.jetbrains:annotations:21.0.1")
-        compileOnly("org.spigotmc:spigot-api:1.18.1-R0.1-SNAPSHOT")
+        compileOnly("org.spigotmc:spigot-api:1.20.1-R0.1-SNAPSHOT")
 
         val adventureVersion = "4.14.0"
         api("net.kyori:adventure-api:$adventureVersion")

--- a/core/src/main/java/dev/triumphteam/gui/builder/item/BaseItemBuilder.java
+++ b/core/src/main/java/dev/triumphteam/gui/builder/item/BaseItemBuilder.java
@@ -23,6 +23,7 @@
  */
 package dev.triumphteam.gui.builder.item;
 
+import com.google.common.base.Preconditions;
 import dev.triumphteam.gui.components.GuiAction;
 import dev.triumphteam.gui.components.exception.GuiException;
 import dev.triumphteam.gui.components.util.ItemNbt;
@@ -31,7 +32,6 @@ import dev.triumphteam.gui.components.util.VersionHelper;
 import dev.triumphteam.gui.guis.GuiItem;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
-import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Material;
@@ -91,7 +91,7 @@ public abstract class BaseItemBuilder<B extends BaseItemBuilder<B>> {
     private ItemMeta meta;
 
     protected BaseItemBuilder(@NotNull final ItemStack itemStack) {
-        Validate.notNull(itemStack, "Item can't be null!");
+        Preconditions.checkNotNull(itemStack, "Item can't be null!");
 
         this.itemStack = itemStack;
         meta = itemStack.hasItemMeta() ? itemStack.getItemMeta() : Bukkit.getItemFactory().getItemMeta(itemStack.getType());

--- a/core/src/main/java/dev/triumphteam/gui/components/util/SkullUtil.java
+++ b/core/src/main/java/dev/triumphteam/gui/components/util/SkullUtil.java
@@ -23,9 +23,15 @@
  */
 package dev.triumphteam.gui.components.util;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
+
+import java.net.URL;
+import java.util.Base64;
 
 public final class SkullUtil {
 
@@ -33,6 +39,7 @@ public final class SkullUtil {
      * The main SKULL material for the version
      */
     private static final Material SKULL = getSkullMaterial();
+    private static final Gson GSON = new Gson();
 
     /**
      * Gets the correct {@link Material} for the version
@@ -70,6 +77,37 @@ public final class SkullUtil {
         }
 
         return item.getType() == SKULL;
+    }
+
+    /**
+     * Decode a base64 string and extract the url of the skin. Example:
+     * <br>
+     * - Base64: {@code eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZGNlYjE3MDhkNTQwNGVmMzI2MTAzZTdiNjA1NTljOTE3OGYzZGNlNzI5MDA3YWM5YTBiNDk4YmRlYmU0NjEwNyJ9fX0=}
+     * <br>
+     * - JSON: {@code {"textures":{"SKIN":{"url":"http://textures.minecraft.net/texture/dceb1708d5404ef326103e7b60559c9178f3dce729007ac9a0b498bdebe46107"}}}}
+     * <br>
+     * - Result: {@code http://textures.minecraft.net/texture/dceb1708d5404ef326103e7b60559c9178f3dce729007ac9a0b498bdebe46107}
+     * @param base64Texture the texture
+     * @return the url of the texture if found, otherwise {@code null}
+     */
+    public static String getSkinUrl(String base64Texture) {
+        final String decoded = new String(Base64.getDecoder().decode(base64Texture));
+        final JsonObject object = GSON.fromJson(decoded, JsonObject.class);
+
+        final JsonElement textures = object.get("textures");
+
+        if (textures == null) {
+            return null;
+        }
+
+        final JsonElement skin = textures.getAsJsonObject().get("SKIN");
+
+        if (skin == null) {
+            return null;
+        }
+
+        final JsonElement url = skin.getAsJsonObject().get("url");
+        return url == null ? null : url.getAsString();
     }
 
 }

--- a/core/src/main/java/dev/triumphteam/gui/components/util/SkullUtil.java
+++ b/core/src/main/java/dev/triumphteam/gui/components/util/SkullUtil.java
@@ -30,7 +30,6 @@ import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-import java.net.URL;
 import java.util.Base64;
 
 public final class SkullUtil {

--- a/core/src/main/java/dev/triumphteam/gui/components/util/VersionHelper.java
+++ b/core/src/main/java/dev/triumphteam/gui/components/util/VersionHelper.java
@@ -49,6 +49,8 @@ public final class VersionHelper {
     private static final int V1_16_5 = 1165;
     // SkullMeta#setOwningPlayer was added
     private static final int V1_12_1 = 1121;
+    // PlayerProfile API
+    private static final int V1_20_1 = 1201;
 
     private static final int CURRENT_VERSION = getCurrentVersion();
 
@@ -85,6 +87,11 @@ public final class VersionHelper {
      * Checks if the version has {@link org.bukkit.inventory.meta.ItemMeta#setCustomModelData(Integer)}
      */
     public static final boolean IS_CUSTOM_MODEL_DATA = CURRENT_VERSION >= V1_14;
+
+    /**
+     * Checks if the version has {@link org.bukkit.profile.PlayerProfile}
+     */
+    public static final boolean IS_PLAYER_PROFILE_API = CURRENT_VERSION >= V1_20_1;
 
     /**
      * Check if the server has access to the Paper API

--- a/core/src/main/java/dev/triumphteam/gui/guis/GuiItem.java
+++ b/core/src/main/java/dev/triumphteam/gui/guis/GuiItem.java
@@ -23,9 +23,9 @@
  */
 package dev.triumphteam.gui.guis;
 
+import com.google.common.base.Preconditions;
 import dev.triumphteam.gui.components.GuiAction;
 import dev.triumphteam.gui.components.util.ItemNbt;
-import org.apache.commons.lang.Validate;
 import org.bukkit.Material;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
@@ -57,7 +57,7 @@ public class GuiItem {
      * @param action    The {@link GuiAction} to run when clicking on the Item
      */
     public GuiItem(@NotNull final ItemStack itemStack, @Nullable final GuiAction<@NotNull InventoryClickEvent> action) {
-        Validate.notNull(itemStack, "The ItemStack for the GUI Item cannot be null!");
+        Preconditions.checkNotNull(itemStack, "The ItemStack for the GUI Item cannot be null!");
 
         this.action = action;
 
@@ -99,7 +99,7 @@ public class GuiItem {
      * @param itemStack The new {@link ItemStack}
      */
     public void setItemStack(@NotNull final ItemStack itemStack) {
-        Validate.notNull(itemStack, "The ItemStack for the GUI Item cannot be null!");
+        Preconditions.checkNotNull(itemStack, "The ItemStack for the GUI Item cannot be null!");
         this.itemStack = ItemNbt.setString(itemStack, "mf-gui", uuid.toString());
     }
 


### PR DESCRIPTION
I've also got rid of `org.apache.commons.lang.Validate` because apache commons `lang` was updated to `lang3` and the package got changed, google's Precondition does the same thing