### PR TITLE
Improve performance of addItem

### DIFF
--- a/core/src/main/java/dev/triumphteam/gui/guis/BaseGui.java
+++ b/core/src/main/java/dev/triumphteam/gui/guis/BaseGui.java
@@ -327,24 +327,21 @@ public abstract class BaseGui implements InventoryHolder {
      *                     and there are more items to be added
      */
     public void addItem(final boolean expandIfFull, @NotNull final GuiItem... items) {
-        final List<GuiItem> notAddedItems = new ArrayList<>();
+        final List<GuiItem> notAddedItems = new ArrayList<>(items.length);
 
+        int slot = 0;
         for (final GuiItem guiItem : items) {
-            for (int slot = 0; slot < rows * 9; slot++) {
-                if (guiItems.get(slot) != null) {
-                    if (slot == rows * 9 - 1) {
-                        notAddedItems.add(guiItem);
-                    }
-                    continue;
-                }
-
-                guiItems.put(slot, guiItem);
-                break;
+            if (slot >= size) {
+                if (rows == 6) return; // our work is done
+                notAddedItems.add(guiItem);
+                continue;
             }
+
+            while (this.guiItems.containsKey(slot)) slot++;
+            this.guiItems.put(slot, guiItem);
         }
 
-        if (!expandIfFull || this.rows >= 6 ||
-                notAddedItems.isEmpty() ||
+        if (!expandIfFull || notAddedItems.isEmpty() ||
                 (this.guiType != null && this.guiType != GuiType.CHEST)) {
             return;
         }

--- a/core/src/main/java/dev/triumphteam/gui/guis/BaseGui.java
+++ b/core/src/main/java/dev/triumphteam/gui/guis/BaseGui.java
@@ -187,16 +187,40 @@ public abstract class BaseGui implements InventoryHolder {
     }
 
     /**
+     * Utility Methods
+     */
+
+    /**
      * Copy a set into an EnumSet, required because {@link EnumSet#copyOf(EnumSet)} throws an exception if the collection passed as argument is empty.
      *
      * @param set The set to be copied.
      * @return An EnumSet with the provided elements from the original set.
      */
     @NotNull
-    private Set<InteractionModifier> safeCopyOf(@NotNull final Set<InteractionModifier> set) {
+    private static Set<InteractionModifier> safeCopyOf(@NotNull final Set<InteractionModifier> set) {
         if (set.isEmpty()) return EnumSet.noneOf(InteractionModifier.class);
         else return EnumSet.copyOf(set);
     }
+
+    private static boolean sizing(List<GuiItem> items, GuiItem item, int rows) {
+        return (rows == 6) ? false : items.add(item);
+    }
+
+    private static int getValidSlot(final Map<Integer, GuiItem> guiItems, final int beginningIndex, final boolean check) {
+        int slot = beginningIndex;
+        while (guiItems.containsKey(slot)) slot++;
+
+        if (!check) return slot;
+        if (slot >= size) {
+            boolean isResizable = sizing(notAddedItems, guiItem, rows);
+            if (isResizable) continue;
+            return -1;
+        }
+    }
+
+    /**
+     * Instance Methods
+     */
 
     /**
      * Gets the GUI's title as string.
@@ -329,15 +353,15 @@ public abstract class BaseGui implements InventoryHolder {
     public void addItem(final boolean expandIfFull, @NotNull final GuiItem... items) {
         final List<GuiItem> notAddedItems = new ArrayList<>(items.length);
 
-        int slot = 0;
+        int slot = getValidSlot(this.guiItems, slot, false);
         for (final GuiItem guiItem : items) {
             if (slot >= size) {
-                if (rows == 6) return; // our work is done
-                notAddedItems.add(guiItem);
-                continue;
+                boolean isResizable = sizing(notAddedItems, guiItem, rows);
+                if (isResizable) continue;
+                return;
             }
 
-            while (this.guiItems.containsKey(slot)) slot++;
+            slot = getValidSlot(this.guiItems, slot, true);
             this.guiItems.put(slot, guiItem);
         }
 


### PR DESCRIPTION
Here's how the old addItem worked:
```java
for (int slot = 0; slot < rows * 9; slot++) { // O(n)
    if (guiItems.get(slot) != null) {
        if (slot == rows * 9 - 1) {
            notAddedItems.add(guiItem);
        }
        continue;
    }

    guiItems.put(slot, guiItem);
    break;
}
 ```
 
 First, it would go through EVERY slot in the inventory for each item, if it contains an item, then we see if the slot equals the size of the inventory size, if yes, add the item, continue whether it did.
 
if it didn't contain an item, add an item and break the loop.
this loop is going to execute for EACH item, the time complexity looks like O(n).

now here's how the NEW addItem works:
```java
final List<GuiItem> notAddedItems = new ArrayList<>(items.length);

int slot = 0;
for (final GuiItem guiItem : items) {
    if (slot >= size) {
        if (rows == 6) return; // our work is done
        notAddedItems.add(guiItem);
        continue;
    }

    while (this.guiItems.containsKey(slot)) slot++; // O(log n) at worst case senario because incrementation is almost equivalent to no lines anyways 
    this.guiItems.put(slot, guiItem);
}
```

ignoring that I presized notAddedItems (default is 16)
this checks if the slot >= size, if true then it checks if rows equals 6 and returns if true (because unable to resize)
if false then adds the item and goes on with its day.

now the REAL improvement is that instead of looping through every slot for ONE item, it checks for each slot and increments for every found item in the slot.

if we find one empty then put the item

this bumps up the time complexity from an estimated O(n) to (around or close to) O(log n)