### PR TITLE
add 1.20.5 support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ allprojects {
         mavenLocal()
         mavenCentral()
         maven("https://hub.spigotmc.org/nexus/content/groups/public/")
+        maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
     }
 }
 
@@ -19,17 +20,17 @@ subprojects {
     }
 
     group = "dev.triumphteam"
-    version = "3.1.8-SNAPSHOT"
+    version = "3.1.8"
 
     dependencies {
         compileOnly("org.jetbrains:annotations:21.0.1")
-        compileOnly("org.spigotmc:spigot-api:1.20.1-R0.1-SNAPSHOT")
+        compileOnly("org.spigotmc:spigot-api:1.20.2-R0.1-SNAPSHOT")
 
-        val adventureVersion = "4.16.0"
+        val adventureVersion = "4.17.0"
         api("net.kyori:adventure-api:$adventureVersion")
         api("net.kyori:adventure-text-serializer-legacy:$adventureVersion")
         api("net.kyori:adventure-text-serializer-gson:$adventureVersion")
-        api("net.kyori:adventure-platform-bukkit:4.3.2")
+        api("net.kyori:adventure-platform-bukkit:4.3.3-SNAPSHOT")
     }
 
     license {
@@ -41,10 +42,9 @@ subprojects {
 
     tasks {
         withType<JavaCompile> {
-            /*sourceCompatibility = "1.8"
-            targetCompatibility = "1.8"*/
+            sourceCompatibility = JavaVersion.VERSION_1_8.toString()
+            targetCompatibility = JavaVersion.VERSION_1_8.toString()
             options.encoding = "UTF-8"
         }
     }
-
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,10 +25,11 @@ subprojects {
         compileOnly("org.jetbrains:annotations:21.0.1")
         compileOnly("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
 
-        val adventureVersion = "4.14.0"
+        val adventureVersion = "4.16.0"
         api("net.kyori:adventure-api:$adventureVersion")
         api("net.kyori:adventure-text-serializer-legacy:$adventureVersion")
         api("net.kyori:adventure-text-serializer-gson:$adventureVersion")
+        api("net.kyori:adventure-platform-bukkit:4.3.2")
     }
 
     license {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ allprojects {
     repositories {
         mavenLocal()
         mavenCentral()
-        maven("https://repo.papermc.io/repository/maven-public/")
+        maven("https://hub.spigotmc.org/nexus/content/groups/public/")
     }
 }
 
@@ -23,7 +23,7 @@ subprojects {
 
     dependencies {
         compileOnly("org.jetbrains:annotations:21.0.1")
-        compileOnly("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
+        compileOnly("org.spigotmc:spigot-api:1.20.1-R0.1-SNAPSHOT")
 
         val adventureVersion = "4.16.0"
         api("net.kyori:adventure-api:$adventureVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ subprojects {
     }
 
     group = "dev.triumphteam"
-    version = "3.1.7"
+    version = "3.1.8-SNAPSHOT"
 
     dependencies {
         compileOnly("org.jetbrains:annotations:21.0.1")
@@ -41,8 +41,8 @@ subprojects {
 
     tasks {
         withType<JavaCompile> {
-            sourceCompatibility = "1.8"
-            targetCompatibility = "1.8"
+            /*sourceCompatibility = "1.8"
+            targetCompatibility = "1.8"*/
             options.encoding = "UTF-8"
         }
     }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -79,7 +79,7 @@ tasks {
                         password = System.getenv("REPO_PASS")
                     }
 
-                    url = uri("https://repo.mattstudios.me/artifactory/public-snapshot/")
+                    url = uri("https://repo.triumphteam.dev/snapshots/")
                     return@maven
                 }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -14,6 +14,11 @@ dependencies {
 
 val javaComponent: SoftwareComponent = components["java"]
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 tasks {
 
     val sourcesJar by creating(Jar::class) {
@@ -102,5 +107,4 @@ tasks {
         useInMemoryPgpKeys(signingKey, secretKey, signingPassword)*/
         sign(publishing.publications["maven"])
     }
-
 }

--- a/core/src/main/java/dev/triumphteam/gui/builder/item/BannerBuilder.java
+++ b/core/src/main/java/dev/triumphteam/gui/builder/item/BannerBuilder.java
@@ -83,7 +83,6 @@ public final class BannerBuilder extends BaseItemBuilder<BannerBuilder> {
     @Contract("_ -> this")
     public BannerBuilder baseColor(@NotNull final DyeColor color) {
         final BannerMeta bannerMeta = (BannerMeta) getMeta();
-
         bannerMeta.setBaseColor(color);
         setMeta(bannerMeta);
         return this;

--- a/core/src/main/java/dev/triumphteam/gui/builder/item/BaseItemBuilder.java
+++ b/core/src/main/java/dev/triumphteam/gui/builder/item/BaseItemBuilder.java
@@ -1,18 +1,18 @@
 /**
  * MIT License
- * <p>
+ *
  * Copyright (c) 2021 TriumphTeam
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/core/src/main/java/dev/triumphteam/gui/components/exception/GuiException.java
+++ b/core/src/main/java/dev/triumphteam/gui/components/exception/GuiException.java
@@ -24,7 +24,12 @@
 package dev.triumphteam.gui.components.exception;
 
 public final class GuiException extends RuntimeException {
+
     public GuiException(String message) {
         super(message);
+    }
+
+    public GuiException(String message, Exception cause) {
+        super(message, cause);
     }
 }

--- a/core/src/main/java/dev/triumphteam/gui/components/util/ItemNbt.java
+++ b/core/src/main/java/dev/triumphteam/gui/components/util/ItemNbt.java
@@ -1,18 +1,18 @@
 /**
  * MIT License
- * <p>
+ *
  * Copyright (c) 2021 TriumphTeam
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/core/src/main/java/dev/triumphteam/gui/components/util/ItemNbt.java
+++ b/core/src/main/java/dev/triumphteam/gui/components/util/ItemNbt.java
@@ -1,18 +1,18 @@
 /**
  * MIT License
- *
+ * <p>
  * Copyright (c) 2021 TriumphTeam
- *
+ * <p>
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * <p>
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- *
+ * <p>
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/core/src/main/java/dev/triumphteam/gui/components/util/VersionHelper.java
+++ b/core/src/main/java/dev/triumphteam/gui/components/util/VersionHelper.java
@@ -101,11 +101,6 @@ public final class VersionHelper {
     public static final boolean IS_ITEM_NAME_COMPONENT = CURRENT_VERSION >= V1_20_5;
 
     /**
-     * Checks if the server is Folia
-     */
-    public static final boolean IS_FOLIA = checkFolia();
-
-    /**
      * Check if the server has access to the Paper API
      * Taken from <a href="https://github.com/PaperMC/PaperLib">PaperLib</a>
      *
@@ -114,21 +109,6 @@ public final class VersionHelper {
     private static boolean checkPaper() {
         try {
             Class.forName("com.destroystokyo.paper.PaperConfig");
-            return true;
-        } catch (ClassNotFoundException ignored) {
-            return false;
-        }
-    }
-
-    /**
-     * Check if the server has access to the Folia API
-     * Taken from <a href="https://github.com/PaperMC/Folia">Folia</a>
-     *
-     * @return True if on Folia server (or forks), false anything else
-     */
-    private static boolean checkFolia() {
-        try {
-            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
             return true;
         } catch (ClassNotFoundException ignored) {
             return false;

--- a/core/src/main/java/dev/triumphteam/gui/components/util/VersionHelper.java
+++ b/core/src/main/java/dev/triumphteam/gui/components/util/VersionHelper.java
@@ -118,11 +118,11 @@ public final class VersionHelper {
     /**
      * Gets the current server version
      *
-     * @return A protocol like number representing the version, for example 1.16.5 - 1165
+     * @return A protocol like number representing the version, for example, 1.16.5 -> 1165
      */
     private static int getCurrentVersion() {
         // No need to cache since will only run once
-        final Matcher matcher = Pattern.compile("(?<version>\\d+\\.\\d+)(?<patch>\\.\\d+)?").matcher(getGameVersion());
+        final Matcher matcher = Pattern.compile("(?<version>\\d+\\.\\d+)(?<patch>\\.\\d+)?").matcher(Bukkit.getBukkitVersion());
 
         final StringBuilder stringBuilder = new StringBuilder();
         if (matcher.find()) {
@@ -139,16 +139,6 @@ public final class VersionHelper {
         if (version == null) throw new GuiException("Could not retrieve server version!");
 
         return version;
-    }
-
-    private static String getGameVersion() {
-        try {
-            // Paper method that was added in 2020
-            return Bukkit.getServer().getMinecraftVersion();
-        } catch (NoSuchMethodError ignored) {
-            final String version = Bukkit.getServer().getClass().getPackage().getName();
-            return version.substring(version.lastIndexOf('.') + 1);
-        }
     }
 
     public static Class<?> craftClass(@NotNull final String name) throws ClassNotFoundException {

--- a/core/src/main/java/dev/triumphteam/gui/components/util/VersionHelper.java
+++ b/core/src/main/java/dev/triumphteam/gui/components/util/VersionHelper.java
@@ -55,50 +55,42 @@ public final class VersionHelper {
     private static final int V1_20_5 = 1205;
 
     private static final int CURRENT_VERSION = getCurrentVersion();
-
-    private static final boolean IS_PAPER = checkPaper();
-
     /**
      * Checks if the version supports Components or not
      * Spigot always false
      */
     public static final boolean IS_COMPONENT_LEGACY = CURRENT_VERSION < V1_16_5;
-
     /**
      * Checks if the version is lower than 1.13 due to the item changes
      */
     public static final boolean IS_ITEM_LEGACY = CURRENT_VERSION < V1_13;
-
     /**
      * Checks if the version supports the {@link org.bukkit.inventory.meta.ItemMeta#setUnbreakable(boolean)} method
      */
     public static final boolean IS_UNBREAKABLE_LEGACY = CURRENT_VERSION < V1_11;
-
     /**
      * Checks if the version supports {@link org.bukkit.persistence.PersistentDataContainer}
      */
     public static final boolean IS_PDC_VERSION = CURRENT_VERSION >= V1_14;
-
     /**
      * Checks if the version doesn't have {@link org.bukkit.inventory.meta.SkullMeta#setOwningPlayer(OfflinePlayer)} and
      * {@link org.bukkit.inventory.meta.SkullMeta#setOwner(String)} should be used instead
      */
     public static final boolean IS_SKULL_OWNER_LEGACY = CURRENT_VERSION < V1_12_1;
-
     /**
      * Checks if the version has {@link org.bukkit.inventory.meta.ItemMeta#setCustomModelData(Integer)}
      */
     public static final boolean IS_CUSTOM_MODEL_DATA = CURRENT_VERSION >= V1_14;
-
     /**
      * Checks if the version has {@link org.bukkit.profile.PlayerProfile}
      */
     public static final boolean IS_PLAYER_PROFILE_API = CURRENT_VERSION >= V1_20_1;
-
     /**
      * Starting with version 1.20.5 the internal field referenced by {@link ItemMeta#getDisplayName()} is no longer a string
      */
     public static final boolean IS_ITEM_NAME_COMPONENT = CURRENT_VERSION >= V1_20_5;
+    private static final boolean IS_PAPER = checkPaper();
+    public static final boolean IS_FOLIA = checkFolia();
 
     /**
      * Check if the server has access to the Paper API
@@ -109,6 +101,21 @@ public final class VersionHelper {
     private static boolean checkPaper() {
         try {
             Class.forName("com.destroystokyo.paper.PaperConfig");
+            return true;
+        } catch (ClassNotFoundException ignored) {
+            return false;
+        }
+    }
+
+    /**
+     * Check if the server has access to the Folia API
+     * Taken from <a href="https://github.com/PaperMC/Folia">Folia</a>
+     *
+     * @return True if on Folia server (or forks), false anything else
+     */
+    private static boolean checkFolia() {
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
             return true;
         } catch (ClassNotFoundException ignored) {
             return false;

--- a/core/src/main/java/dev/triumphteam/gui/components/util/VersionHelper.java
+++ b/core/src/main/java/dev/triumphteam/gui/components/util/VersionHelper.java
@@ -27,6 +27,7 @@ import com.google.common.primitives.Ints;
 import dev.triumphteam.gui.components.exception.GuiException;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.regex.Matcher;
@@ -37,7 +38,7 @@ import java.util.regex.Pattern;
  */
 public final class VersionHelper {
 
-    private static final String NMS_VERSION = getNmsVersion();
+    private static final String CRAFTBUKKIT_PACKAGE = Bukkit.getServer().getClass().getPackage().getName();
 
     // Unbreakable change
     private static final int V1_11 = 1110;
@@ -51,6 +52,7 @@ public final class VersionHelper {
     private static final int V1_12_1 = 1121;
     // PlayerProfile API
     private static final int V1_20_1 = 1201;
+    private static final int V1_20_5 = 1205;
 
     private static final int CURRENT_VERSION = getCurrentVersion();
 
@@ -94,6 +96,11 @@ public final class VersionHelper {
     public static final boolean IS_PLAYER_PROFILE_API = CURRENT_VERSION >= V1_20_1;
 
     /**
+     * Starting with version 1.20.5 the internal field referenced by {@link ItemMeta#getDisplayName()} is no longer a string
+     */
+    public static final boolean IS_ITEM_NAME_COMPONENT = CURRENT_VERSION >= V1_20_5;
+
+    /**
      * Checks if the server is Folia
      */
     public static final boolean IS_FOLIA = checkFolia();
@@ -135,7 +142,7 @@ public final class VersionHelper {
      */
     private static int getCurrentVersion() {
         // No need to cache since will only run once
-        final Matcher matcher = Pattern.compile("(?<version>\\d+\\.\\d+)(?<patch>\\.\\d+)?").matcher(Bukkit.getBukkitVersion());
+        final Matcher matcher = Pattern.compile("(?<version>\\d+\\.\\d+)(?<patch>\\.\\d+)?").matcher(getGameVersion());
 
         final StringBuilder stringBuilder = new StringBuilder();
         if (matcher.find()) {
@@ -154,13 +161,18 @@ public final class VersionHelper {
         return version;
     }
 
-    private static String getNmsVersion() {
-        final String version = Bukkit.getServer().getClass().getPackage().getName();
-        return version.substring(version.lastIndexOf('.') + 1);
+    private static String getGameVersion() {
+        try {
+            // Paper method that was added in 2020
+            return Bukkit.getServer().getMinecraftVersion();
+        } catch (NoSuchMethodError ignored) {
+            final String version = Bukkit.getServer().getClass().getPackage().getName();
+            return version.substring(version.lastIndexOf('.') + 1);
+        }
     }
 
     public static Class<?> craftClass(@NotNull final String name) throws ClassNotFoundException {
-        return Class.forName("org.bukkit.craftbukkit." + NMS_VERSION + "." + name);
+        return Class.forName(CRAFTBUKKIT_PACKAGE + "." + name);
     }
 
 }

--- a/core/src/main/java/dev/triumphteam/gui/guis/BaseGui.java
+++ b/core/src/main/java/dev/triumphteam/gui/guis/BaseGui.java
@@ -1,18 +1,18 @@
 /**
  * MIT License
- * <p>
+ *
  * Copyright (c) 2021 TriumphTeam
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/core/src/main/java/dev/triumphteam/gui/guis/BaseGui.java
+++ b/core/src/main/java/dev/triumphteam/gui/guis/BaseGui.java
@@ -29,7 +29,6 @@ import dev.triumphteam.gui.components.InteractionModifier;
 import dev.triumphteam.gui.components.exception.GuiException;
 import dev.triumphteam.gui.components.util.GuiFiller;
 import dev.triumphteam.gui.components.util.Legacy;
-import dev.triumphteam.gui.components.util.VersionHelper;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.HumanEntity;
@@ -439,15 +438,6 @@ public abstract class BaseGui implements InventoryHolder {
      * @param runCloseAction If should or not run the close action.
      */
     public void close(@NotNull final HumanEntity player, final boolean runCloseAction) {
-        if (VersionHelper.IS_FOLIA) {
-            player.getScheduler().runDelayed(plugin, task -> {
-                this.runCloseAction = runCloseAction;
-                player.closeInventory();
-                this.runCloseAction = true;
-            }, null, 2L);
-            return;
-        }
-
         Bukkit.getScheduler().runTaskLater(plugin, () -> {
             this.runCloseAction = runCloseAction;
             player.closeInventory();

--- a/core/src/main/java/dev/triumphteam/gui/guis/GuiItem.java
+++ b/core/src/main/java/dev/triumphteam/gui/guis/GuiItem.java
@@ -1,18 +1,18 @@
 /**
  * MIT License
- * <p>
+ *
  * Copyright (c) 2021 TriumphTeam
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/core/src/main/java/dev/triumphteam/gui/guis/GuiItem.java
+++ b/core/src/main/java/dev/triumphteam/gui/guis/GuiItem.java
@@ -1,18 +1,18 @@
 /**
  * MIT License
- *
+ * <p>
  * Copyright (c) 2021 TriumphTeam
- *
+ * <p>
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * <p>
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- *
+ * <p>
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -41,14 +41,12 @@ import java.util.UUID;
 @SuppressWarnings("unused")
 public class GuiItem {
 
-    // Action to do when clicking on the item
-    private GuiAction<InventoryClickEvent> action;
-
-    // The ItemStack of the GuiItem
-    private ItemStack itemStack;
-
     // Random UUID to identify the item when clicking
     private final UUID uuid = UUID.randomUUID();
+    // Action to do when clicking on the item
+    private GuiAction<InventoryClickEvent> action;
+    // The ItemStack of the GuiItem
+    private ItemStack itemStack;
 
     /**
      * Main constructor of the GuiItem
@@ -62,7 +60,7 @@ public class GuiItem {
         this.action = action;
 
         // Sets the UUID to an NBT tag to be identifiable later
-        this.itemStack = ItemNbt.setString(itemStack.clone(), "mf-gui", uuid.toString());
+        setItemStack(itemStack);
     }
 
     /**
@@ -94,25 +92,6 @@ public class GuiItem {
     }
 
     /**
-     * Replaces the {@link ItemStack} of the GUI Item
-     *
-     * @param itemStack The new {@link ItemStack}
-     */
-    public void setItemStack(@NotNull final ItemStack itemStack) {
-        Preconditions.checkNotNull(itemStack, "The ItemStack for the GUI Item cannot be null!");
-        this.itemStack = ItemNbt.setString(itemStack.clone(), "mf-gui", uuid.toString());
-    }
-
-    /**
-     * Replaces the {@link GuiAction} of the current GUI Item
-     *
-     * @param action The new {@link GuiAction} to set
-     */
-    public void setAction(@Nullable final GuiAction<@NotNull InventoryClickEvent> action) {
-        this.action = action;
-    }
-
-    /**
      * Gets the GuiItem's {@link ItemStack}
      *
      * @return The {@link ItemStack}
@@ -120,6 +99,20 @@ public class GuiItem {
     @NotNull
     public ItemStack getItemStack() {
         return itemStack;
+    }
+
+    /**
+     * Replaces the {@link ItemStack} of the GUI Item
+     *
+     * @param itemStack The new {@link ItemStack}
+     */
+    public void setItemStack(@NotNull final ItemStack itemStack) {
+        Preconditions.checkNotNull(itemStack, "The ItemStack for the GUI Item cannot be null!");
+        if (itemStack.getType() != Material.AIR) {
+            this.itemStack = ItemNbt.setString(itemStack.clone(), "mf-gui", uuid.toString());
+        } else {
+            this.itemStack = itemStack.clone();
+        }
     }
 
     /**
@@ -136,5 +129,14 @@ public class GuiItem {
     @Nullable
     GuiAction<InventoryClickEvent> getAction() {
         return action;
+    }
+
+    /**
+     * Replaces the {@link GuiAction} of the current GUI Item
+     *
+     * @param action The new {@link GuiAction} to set
+     */
+    public void setAction(@Nullable final GuiAction<@NotNull InventoryClickEvent> action) {
+        this.action = action;
     }
 }

--- a/core/src/main/java/dev/triumphteam/gui/guis/PaginatedGui.java
+++ b/core/src/main/java/dev/triumphteam/gui/guis/PaginatedGui.java
@@ -1,18 +1,18 @@
 /**
  * MIT License
- * <p>
+ *
  * Copyright (c) 2021 TriumphTeam
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/core/src/main/java/dev/triumphteam/gui/guis/PaginatedGui.java
+++ b/core/src/main/java/dev/triumphteam/gui/guis/PaginatedGui.java
@@ -1,18 +1,18 @@
 /**
  * MIT License
- *
+ * <p>
  * Copyright (c) 2021 TriumphTeam
- *
+ * <p>
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * <p>
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- *
+ * <p>
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -404,13 +404,15 @@ public class PaginatedGui extends BaseGui {
      */
     private void populatePage() {
         // Adds the paginated items to the page
+        int slot = 0;
         for (final GuiItem guiItem : getPageNum(pageNum)) {
-            for (int slot = 0; slot < getRows() * 9; slot++) {
-                if (getGuiItem(slot) != null || getInventory().getItem(slot) != null) continue;
-                currentPage.put(slot, guiItem);
-                getInventory().setItem(slot, guiItem.getItemStack());
-                break;
+            if (getGuiItem(slot) != null || getInventory().getItem(slot) != null) {
+                slot++;
+                continue;
             }
+            currentPage.put(slot, guiItem);
+            getInventory().setItem(slot, guiItem.getItemStack());
+            slot++;
         }
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,3 +7,5 @@ listOf("kotlin").forEach {
     include(it)
     findProject(":$it")?.name = "triumph-gui-$it"
 }
+
+include("test-plugin")


### PR DESCRIPTION
### NOT TESTED

- changes how the MC version is detected
- uses a different ComponentSerializer on 1.20.5+ for the item and lore of the item

Paper post https://forums.papermc.io/threads/important-dev-psa-future-removal-of-cb-package-relocation.1106/