### PR TITLE
Fix PDC when using a library loader

### DIFF
--- a/core/src/main/java/dev/triumphteam/gui/components/nbt/Pdc.java
+++ b/core/src/main/java/dev/triumphteam/gui/components/nbt/Pdc.java
@@ -23,12 +23,12 @@
  */
 package dev.triumphteam.gui.components.nbt;
 
+import dev.triumphteam.gui.TriumphGui;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -41,7 +41,7 @@ public final class Pdc implements NbtWrapper {
     /**
      * Plugin instance required for the {@link NamespacedKey}.
      */
-    private static final Plugin PLUGIN = JavaPlugin.getProvidingPlugin(Pdc.class);
+    private static final Plugin PLUGIN = TriumphGui.getPlugin();
 
     /**
      * Sets an String NBT tag to the an {@link ItemStack}.


### PR DESCRIPTION
Fixes the following error when using Paper's library loader.
```
Caused by: java.lang.IllegalArgumentException: class dev.triumphteam.gui.components.nbt.Pdc is not provided by a interface io.papermc.paper.plugin.provider.classloader.ConfiguredPluginClassLoader
	at org.bukkit.plugin.java.JavaPlugin.getProvidingPlugin(JavaPlugin.java:461) ~[paper-api-1.21.1-R0.1-SNAPSHOT.jar:?]
	at dev.triumphteam.gui.components.nbt.Pdc.<clinit>(Pdc.java:44) ~[?:?]
	... 34 more
```