### PR TITLE
Add item model setter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,5 +21,5 @@ subprojects {
     }
 
     group = "dev.triumphteam"
-    version = "3.1.11"
+    version = "3.1.12"
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 
 dependencies {
     compileOnly("com.mojang:authlib:1.5.25")
-    compileOnly("org.spigotmc:spigot-api:1.20.2-R0.1-SNAPSHOT")
+    compileOnly("org.spigotmc:spigot-api:1.21.4-R0.1-SNAPSHOT")
 
     compileOnly("org.jetbrains:annotations:21.0.1")
 

--- a/core/src/main/java/dev/triumphteam/gui/builder/item/BannerBuilder.java
+++ b/core/src/main/java/dev/triumphteam/gui/builder/item/BannerBuilder.java
@@ -82,9 +82,9 @@ public final class BannerBuilder extends BaseItemBuilder<BannerBuilder> {
     @NotNull
     @Contract("_ -> this")
     public BannerBuilder baseColor(@NotNull final DyeColor color) {
-        final BannerMeta bannerMeta = (BannerMeta) getMeta();
+/*        final BannerMeta bannerMeta = (BannerMeta) getMeta();
         bannerMeta.setBaseColor(color);
-        setMeta(bannerMeta);
+        setMeta(bannerMeta);*/
         return this;
     }
 

--- a/core/src/main/java/dev/triumphteam/gui/builder/item/BaseItemBuilder.java
+++ b/core/src/main/java/dev/triumphteam/gui/builder/item/BaseItemBuilder.java
@@ -36,6 +36,7 @@ import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemFlag;
@@ -434,6 +435,24 @@ public abstract class BaseItemBuilder<B extends BaseItemBuilder<B>> {
     public B model(final int modelData) {
         if (VersionHelper.IS_CUSTOM_MODEL_DATA) {
             meta.setCustomModelData(modelData);
+        }
+
+        return (B) this;
+    }
+
+    /**
+     * Sets the item model of the item
+     * Added in 1.21.4
+     *
+     * @param modelKey The item model key from the resource pack
+     * @return {@link ItemBuilder}
+     * @since 3.1.12
+     */
+    @NotNull
+    @Contract("_ -> this")
+    public B model(final NamespacedKey modelKey) {
+        if (VersionHelper.IS_ITEM_MODEL) {
+            meta.setItemModel(modelKey);
         }
 
         return (B) this;

--- a/core/src/main/java/dev/triumphteam/gui/components/util/VersionHelper.java
+++ b/core/src/main/java/dev/triumphteam/gui/components/util/VersionHelper.java
@@ -26,6 +26,7 @@ package dev.triumphteam.gui.components.util;
 import com.google.common.primitives.Ints;
 import dev.triumphteam.gui.components.exception.GuiException;
 import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
@@ -53,6 +54,8 @@ public final class VersionHelper {
     // PlayerProfile API
     private static final int V1_20_1 = 1201;
     private static final int V1_20_5 = 1205;
+    // Item model
+    private static final int V1_21_4 = 1214;
 
     private static final int CURRENT_VERSION = getCurrentVersion();
     /**
@@ -81,6 +84,10 @@ public final class VersionHelper {
      * Checks if the version has {@link org.bukkit.inventory.meta.ItemMeta#setCustomModelData(Integer)}
      */
     public static final boolean IS_CUSTOM_MODEL_DATA = CURRENT_VERSION >= V1_14;
+    /**
+     * Check if the version has {@link org.bukkit.inventory.meta.ItemMeta#setItemModel(NamespacedKey)}
+     */
+    public static final boolean IS_ITEM_MODEL = CURRENT_VERSION >= V1_21_4;
     /**
      * Checks if the version has {@link org.bukkit.profile.PlayerProfile}
      */


### PR DESCRIPTION
Hello,

Minecraft 1.21.4 introduced item_model component, would be nice to be able to use it.
Unfortunately BannerMeta#setBaseColor(DyeColor) was completely removed in spigot api 1.21, so i was not sure what to do with it...